### PR TITLE
Kennric/local conf

### DIFF
--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -1,7 +1,7 @@
 from yaml import load
 import os
 
-DEFAULT_CONFIG_DIR = '/opt/whats_fresh/config'
+DEFAULT_CONFIG_DIR = './'
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
 
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yml')

--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -3,7 +3,7 @@ import os
 
 print("getting yaml config")
 
-DEFAULT_CONFIG_DIR = './'
+DEFAULT_CONFIG_DIR = 'whats_fresh'
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
 
 print(CONFIG_DIR)

--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -1,7 +1,7 @@
 from yaml import load
 import os
 
-DEFAULT_CONFIG_DIR = 'whats_fresh'
+DEFAULT_CONFIG_DIR = os.path.dirname(os.path.realpath(__file__)) 
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yml')
 

--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -1,13 +1,8 @@
 from yaml import load
 import os
 
-print("getting yaml config")
-
 DEFAULT_CONFIG_DIR = 'whats_fresh'
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
-
-print(CONFIG_DIR)
-
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yml')
 
 # Open our yaml config and override settings values with it's config

--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -1,8 +1,12 @@
 from yaml import load
 import os
 
+print("getting yaml config")
+
 DEFAULT_CONFIG_DIR = './'
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
+
+print(CONFIG_DIR)
 
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yml')
 

--- a/whats_fresh/yaml_config.py
+++ b/whats_fresh/yaml_config.py
@@ -1,7 +1,7 @@
 from yaml import load
 import os
 
-DEFAULT_CONFIG_DIR = os.path.dirname(os.path.realpath(__file__)) 
+DEFAULT_CONFIG_DIR = os.path.dirname(os.path.realpath(__file__))
 CONFIG_DIR = os.environ.get('WF_CONFIG_DIR', DEFAULT_CONFIG_DIR)
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.yml')
 


### PR DESCRIPTION
Looking for config.yml in /opt is problematic in a shared hosting environment where you don't have root access. Instead, look in the local app directory and allow for using environment variables to get it from somewhere else.
